### PR TITLE
Update for Debian 11 (bullseye) base

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,11 +1,11 @@
 # x11docker/xfce
-# 
-# Run XFCE desktop in docker. 
-# Use x11docker to run image. 
-# Get x11docker from github: 
-#   https://github.com/mviereck/x11docker 
 #
-# Examples: 
+# Run XFCE desktop in docker.
+# Use x11docker to run image.
+# Get x11docker from github:
+#   https://github.com/mviereck/x11docker
+#
+# Examples:
 #   - Run desktop:
 #       x11docker --desktop x11docker/xfce
 #   - Run single application:
@@ -24,7 +24,7 @@
 #
 # Look at x11docker --help for further options.
 
-FROM debian:buster
+FROM debian:bullseye
 
 RUN apt-get update && apt-mark hold iptables && \
     env DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
@@ -36,7 +36,6 @@ RUN apt-get update && apt-mark hold iptables && \
     env DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
       xfce4 && \
     env DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
-      gtk3-engines-xfce \
       libgtk-3-bin \
       libpulse0 \
       mousepad \
@@ -54,7 +53,6 @@ RUN apt-get update && apt-mark hold iptables && \
       xfce4-genmon-plugin \
       xfce4-indicator-plugin \
       xfce4-netload-plugin \
-      xfce4-notes-plugin \
       xfce4-places-plugin \
       xfce4-sensors-plugin \
       xfce4-smartbookmark-plugin \

--- a/Dockerfile
+++ b/Dockerfile
@@ -65,6 +65,7 @@ RUN apt-get update && apt-mark hold iptables && \
       libxv1 \
       mesa-utils \
       mesa-utils-extra && \
-    sed -i 's%<property name="ThemeName" type="string" value="Xfce"/>%<property name="ThemeName" type="string" value="Raleigh"/>%' /etc/xdg/xfce4/xfconf/xfce-perchannel-xml/xsettings.xml
+    sed -i 's%<property name="ThemeName" type="string" value="Xfce"/>%<property name="ThemeName" type="string" value="Raleigh"/>%' /etc/xdg/xfce4/xfconf/xfce-perchannel-xml/xsettings.xml && \
+    sed -i 's%^\(use_compositing=\).*%\1false%' /usr/share/xfwm4/defaults
 
 CMD ["startxfce4"]


### PR DESCRIPTION
* changed `FROM` base image from `debian:buster` to `debian:bullseye`
* remove references to packages that no longer exist